### PR TITLE
Complete report to students broken

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -176,7 +176,7 @@ function oublog_user_outline($course, $user, $mod, $oublog) {
  */
 function oublog_user_complete($course, $user, $mod, $oublog) {
     global $CFG, $DB, $PAGE;
-    include_once('locallib.php');
+    include_once($CFG->dirroot.'/mod/oublog/locallib.php');
 
     $oublogoutput = $PAGE->get_renderer('mod_oublog');
 


### PR DESCRIPTION
Complete report to students broken when OuBlog activity is enable in course.
See in: $COURSE > PARTICIPANTS > $STUDENT > ACTIVITY REPORTS > COMPLETE REPORT
