### PR TITLE
Enable support for embedding IFRAME,OBJECT,EMBED tags inside posts  (Update renderer.php)

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -159,7 +159,11 @@ class mod_oublog_renderer extends plugin_renderer_base {
             $post->message = portfolio_rewrite_pluginfile_urls($post->message, $modcontext->id,
                     'mod_oublog', 'message', $post->id, $format);
         }
-        $output .= format_text($post->message, FORMAT_HTML);
+        $formatoptions = new stdClass;
+        $formatoptions->noclean = true;
+        $formatoptions->overflowdiv = true;
+        $formatoptions->context = $context;
+        $output .= format_text($post->message, FORMAT_HTML, $formatoptions);
         $output .= html_writer::end_tag('div');
 
         $fs = get_file_storage();


### PR DESCRIPTION
Enable support for embedding IFRAME,OBJECT,EMBED tags inside posts 
if enabled by $CFG->allowobjectembed and $CFG->enabletrusttext
