### PR TITLE
Display blog's intro above new post form

### DIFF
--- a/editpost.php
+++ b/editpost.php
@@ -159,6 +159,15 @@ if (!$frmpost = $mform->get_data()) {
     $PAGE->set_heading(format_string($course->fullname));
     echo $OUTPUT->header();
 
+    if (!empty($oublog->intro)) {
+        echo $OUTPUT->box(format_module_intro('oublog', $oublog, $cm->id), 'generalbox', 'intro');
+
+        if (!empty($CFG->enableplagiarism)) {
+            require_once($CFG->libdir.'/plagiarismlib.php');
+            echo plagiarism_print_disclosure($cm->id);
+        }
+    }
+    
     $mform->display();
 
     echo $OUTPUT->footer();


### PR DESCRIPTION
We find it very useful for students to see the Teacher's instructions (Intro) displayed above the post form, which help them  follow the rubrics presented by the teacher when submitting a new post to the blog activity.

Please review and see if it can be added.

Nadav :-)
