### PR TITLE
fixing typo in sql; should be lowercase U

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -4344,7 +4344,7 @@ function oublog_get_participation_details($oublog, $groupid, $individual,
         $period .= 'AND timeposted < :timeend ';
     }
     if ($individual > 0 ) {
-        $thispostuser = 'AND U.id = :userid ';
+        $thispostuser = 'AND u.id = :userid ';
         $thiscommentuser = 'AND Ub.id = :userid ';
     }
     if ($oublog->global || ($oublog->maxvisibility == OUBLOG_VISIBILITY_PUBLIC


### PR DESCRIPTION
This looks like a typo, or it wasn't corrected after a copy/paste (Ua and Ub are named, but no uppercase U). It produces an error when students try to access the blog, but works for teachers and administrators. When U.id is changed to u.id, it works as expected.