### PR TITLE
Remove from gradebook when 'grading' is set to 'No grade'

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -382,5 +382,17 @@ function xmldb_oublog_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2015090800, 'oublog');
     }
 
+    if ($oldversion < 2015101501) {
+        // Fix the gradebook entries for all OUblogs with grading == OUBLOG_NO_GRADING.
+        require_once($CFG->dirroot.'/mod/oublog/lib.php');
+        $rs = $DB->get_recordset('oublog', ['grading' => OUBLOG_NO_GRADING]);
+        foreach ($rs as $oublog) {
+            oublog_grade_item_update($oublog);
+        }
+
+        // Oublog savepoint reached.
+        upgrade_mod_savepoint(true, 2015101501, 'oublog');
+    }
+
     return true;
 }

--- a/lib.php
+++ b/lib.php
@@ -970,6 +970,8 @@ function oublog_grade_item_update($oublog, $grades = null) {
     // Use 'grade' or 'scale' depends upon 'grading'.
     if ($oublog->grading == OUBLOG_USE_RATING) {
         $oublogscale = $oublog->scale;
+    } else if ($oublog->grading == OUBLOG_NO_GRADING) {
+        $oublogscale = 0;
     } else {
         $oublogscale = $oublog->grade;
     }

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
  * @package oublog
  **/
 
-$plugin->version = 2015101500;
+$plugin->version = 2015101501;
 $plugin->requires = 2014111000;
 $plugin->component = 'mod_oublog';// Full name of the plugin (used for diagnostics)
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
When the setting 'Grading' is set to 'No grade (default)', the gradebook item is set to 'GRADE_TYPE_VALUE' (unless 'Grading' is set to a different value, then the 'Grade' value is set to 'None', then the 'Grading' value is set back again). It should be set to 'GRADE_TYPE_NONE'.
