### PR TITLE
Fixed typo in get_url method for event class participation_viewed.php

### DIFF
--- a/classes/event/participation_viewed.php
+++ b/classes/event/participation_viewed.php
@@ -72,7 +72,7 @@ class participation_viewed extends \core\event\course_module_viewed {
      * @return \moodle_url
      */
     public function get_url() {
-        return new \moodle_url('\\mod\\oublog\\' . $this->other['logurl']);
+        return new \moodle_url('/mod/oublog/' . $this->other['logurl']);
     }
 
     /**


### PR DESCRIPTION
Hi oublog team,

Very quick and simple patch for the participation event class.

Looks like a simple typo (Windows path by mistake?).

Regards,
Damien
