### PR TITLE
Remove BOM character from lang/es/oublog.php

### DIFF
--- a/lang/es/oublog.php
+++ b/lang/es/oublog.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 $string['oublog'] = 'OU blog';
 $string['modulename'] = 'OU blog';


### PR DESCRIPTION
	modified:   lang/es/oublog.php

removed BOM Character from: lang/es/oublog.php

http://stackoverflow.com/questions/2558172/utf-8-bom-signature-in-php-files

There was an invisible character before the openning PHP tag.

If you are writing a file to the output buffer, and include this module,
that invisible character will get added to the buffer and corrupt the
file.