### PR TITLE
Fix deprecated expectErrorMessage call

### DIFF
--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -1941,7 +1941,7 @@ class oublog_locallib_test extends oublog_test_lib {
         $this->setUser($user);
         list($oublog, $oubloginstance) = oublog_get_personal_blog($USER->id);
         $cm = get_coursemodule_from_instance('oublog', $oublog->id);
-        $this->expectErrorMessage('Sorry: you do not have access to view this page.');
+        $this->expectExceptionMessage('Sorry: you do not have access to view this page.');
         oublog_check_view_permissions($oublog, context_module::instance($cm->id), $cm);
 }
 


### PR DESCRIPTION
Resolves issue https://github.com/moodleou/moodle-mod_oublog/issues/151

## Before
```
php vendor/bin/phpunit --testsuite mod_oublog_testsuite --filter test_oublog_check_view_permissions_personal_restrict
Moodle 4.5.1+ (Build: 20250124), ref: refs/heads/wr-452085-add-submodules
Php: 8.1.29, pgsql: 16.0 (Debian 16.0-1.pgdg120+1), OS: Linux 6.8.0-52-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

W                                                                   1 / 1 (100%)

Time: 00:00.688, Memory: 86.50 MB

There was 1 warning:

1) oublog_locallib_test::test_oublog_check_view_permissions_personal_restrict
Expecting E_ERROR and E_USER_ERROR is deprecated and will no longer be possible in PHPUnit 10.

/var/www/icms/lib/phpunit/classes/advanced_testcase.php:76

WARNINGS!
Tests: 1, Assertions: 2, Warnings: 1.
```
## After
```
php vendor/bin/phpunit --testsuite mod_oublog_testsuite --filter test_oublog_check_view_permissions_personal_restrict
Moodle 4.5.1+ (Build: 20250124), ref: refs/heads/wr-452085-add-submodules
Php: 8.1.29, pgsql: 16.0 (Debian 16.0-1.pgdg120+1), OS: Linux 6.8.0-52-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 00:00.669, Memory: 84.50 MB

OK (1 test, 2 assertions)
```