### PR TITLE
Global blog deletion issue

### DIFF
--- a/classes/task/cron_task.php
+++ b/classes/task/cron_task.php
@@ -50,51 +50,52 @@ class cron_task extends \core\task\scheduled_task {
         $fs = get_file_storage();
         $timeframe = strtotime('-90 days');
         if ($personalblog = $DB->get_record('oublog', ['global' => 1], '*', IGNORE_MULTIPLE)) {
-            $cm = get_coursemodule_from_instance('oublog', $personalblog->id);
-            $context = \context_module::instance($cm->id);
-            $instancesql = "
-                            SELECT op.id
-                              FROM {oublog_instances} bi
-                        INNER JOIN {oublog_posts} op ON bi.id = op.oubloginstancesid
-                             WHERE bi.oublogid = :blogid AND op.timedeleted < :timeframe ";
-            $posts = $DB->get_recordset_sql($instancesql, ['blogid' => $personalblog->id,
-                    'timeframe' => $timeframe]);
-            foreach ($posts as $post) {
-                $transaction = $DB->start_delegated_transaction();
-                // Delete files from this post.
-                $params = ['postid' => $post->id];
-                $fs->delete_area_files_select($context->id, 'mod_oublog', 'message',
-                    'IN (:postid)', $params);
-                $fs->delete_area_files_select($context->id, 'mod_oublog', 'attachment',
-                    'IN (:postid)', $params);
-
-                $commentids = $DB->get_records('oublog_comments', $params, '', 'id');
-                if ($commentids) {
-                    list($insql, $paramsinsql) = $DB->get_in_or_equal(array_keys($commentids), SQL_PARAMS_NAMED);
-                    $fs->delete_area_files_select($context->id, 'mod_oublog', 'messagecomment',
-                                                  $insql, $paramsinsql);
-                    $DB->delete_records_select('oublog_comments', "id $insql", $paramsinsql);
+            if($cm = get_coursemodule_from_instance('oublog', $personalblog->id)){
+                $context = \context_module::instance($cm->id);
+                $instancesql = "
+                                SELECT op.id
+                                  FROM {oublog_instances} bi
+                            INNER JOIN {oublog_posts} op ON bi.id = op.oubloginstancesid
+                                 WHERE bi.oublogid = :blogid AND op.timedeleted < :timeframe ";
+                $posts = $DB->get_recordset_sql($instancesql, ['blogid' => $personalblog->id,
+                        'timeframe' => $timeframe]);
+                foreach ($posts as $post) {
+                    $transaction = $DB->start_delegated_transaction();
+                    // Delete files from this post.
+                    $params = ['postid' => $post->id];
+                    $fs->delete_area_files_select($context->id, 'mod_oublog', 'message',
+                        'IN (:postid)', $params);
+                    $fs->delete_area_files_select($context->id, 'mod_oublog', 'attachment',
+                        'IN (:postid)', $params);
+    
+                    $commentids = $DB->get_records('oublog_comments', $params, '', 'id');
+                    if ($commentids) {
+                        list($insql, $paramsinsql) = $DB->get_in_or_equal(array_keys($commentids), SQL_PARAMS_NAMED);
+                        $fs->delete_area_files_select($context->id, 'mod_oublog', 'messagecomment',
+                                                      $insql, $paramsinsql);
+                        $DB->delete_records_select('oublog_comments', "id $insql", $paramsinsql);
+                    }
+    
+                    $DB->delete_records_select('oublog_comments_moderated', 'postid IN (:postid)', $params);
+    
+                    // Delete all edits (including files) on posts owned by these users
+                    $editids = $DB->get_records('oublog_edits', $params, '', 'id');
+                    if ($editids) {
+                        list($insql, $paramsinsql) = $DB->get_in_or_equal(array_keys($editids), SQL_PARAMS_NAMED);
+                        $fs->delete_area_files_select($context->id, 'mod_oublog', 'edit',
+                                                      $insql, $paramsinsql);
+                        $DB->delete_records_select('oublog_edits', "id $insql", $paramsinsql);
+                    }
+    
+                    // Delete tag instances from all these posts.
+                    $DB->delete_records_select('oublog_taginstances', 'postid IN (:postid)', $params);
+    
+                    // Delete the actual posts.
+                    $DB->delete_records_select('oublog_posts', 'id IN (:postid)', $params);
+                    $transaction->allow_commit();
                 }
-
-                $DB->delete_records_select('oublog_comments_moderated', 'postid IN (:postid)', $params);
-
-                // Delete all edits (including files) on posts owned by these users
-                $editids = $DB->get_records('oublog_edits', $params, '', 'id');
-                if ($editids) {
-                    list($insql, $paramsinsql) = $DB->get_in_or_equal(array_keys($editids), SQL_PARAMS_NAMED);
-                    $fs->delete_area_files_select($context->id, 'mod_oublog', 'edit',
-                                                  $insql, $paramsinsql);
-                    $DB->delete_records_select('oublog_edits', "id $insql", $paramsinsql);
-                }
-
-                // Delete tag instances from all these posts.
-                $DB->delete_records_select('oublog_taginstances', 'postid IN (:postid)', $params);
-
-                // Delete the actual posts.
-                $DB->delete_records_select('oublog_posts', 'id IN (:postid)', $params);
-                $transaction->allow_commit();
+                $posts->close();
             }
-            $posts->close();
         }
     }
 

--- a/lib.php
+++ b/lib.php
@@ -177,7 +177,10 @@ function oublog_delete_instance($oublogid) {
     oublog_grade_item_delete($oublog);
 
     // Delete event in calendar when deleting activity.
-    \core_completion\api::update_completion_date_event($cm->id, 'oublog', $oublogid, null);
+    if (isset($cm)) {
+        \core_completion\api::update_completion_date_event($cm->id, 'oublog', $oublogid, null);
+    }
+
 
     // oublog
     return($DB->delete_records('oublog', array('id'=>$oublog->id)));

--- a/lib.php
+++ b/lib.php
@@ -132,8 +132,10 @@ function oublog_delete_instance($oublogid) {
     }
 
     if ($oublog->global) {
-        throw new moodle_exception('deleteglobalblog', 'oublog');
+        debugging("Skipping deletion of global blog (ID: {$oublogid}). Global blogs cannot be deleted.", DEBUG_DEVELOPER);
+        return false; // Prevent cron failure, but do not delete the blog
     }
+    
 
     if ($instances = $DB->get_records('oublog_instances', array('oublogid'=>$oublog->id))) {
 

--- a/lib.php
+++ b/lib.php
@@ -133,7 +133,7 @@ function oublog_delete_instance($oublogid) {
 
     if ($oublog->global) {
         debugging("Skipping deletion of global blog (ID: {$oublogid}). Global blogs cannot be deleted.", DEBUG_DEVELOPER);
-        return false; // Prevent cron failure, but do not delete the blog
+        return false; // Prevent cron failure, but do not delete the blog.
     }
     
 


### PR DESCRIPTION
Similar issue here,  need to handle it gracefully for global blog delete.

In case of Moodle 4.1.11 (build: 20240610) after deleting the global blog the following error appears in adhoc task:

Adhoc task failed: core_course\task\course_delete_modules,Coding error detected, it must be fixed by a programmer: The course module x could not be deleted. You can't delete the global blog: /opt/vhosts/xxx/www/lib/deprecatedlib.php(3665) #0 /opt/vhosts/xxx/www/mod/oublog/lib.php(125): print_error('deleteglobalblo...', 'oublog')

a user with admin rights can delete a global blog,
after deletion an adhoc task is created: core_course\task\course_delete_modules
the adhoc task failed with the above error

https://github.com/moodleou/moodle-mod_oublog/issues/143